### PR TITLE
Add Referral#referral_activated_users method

### DIFF
--- a/app/models/spree/referral.rb
+++ b/app/models/spree/referral.rb
@@ -12,7 +12,11 @@ module Spree
     end
 
     def referred_orders
-      referred_records.includes({:user => :orders}).collect{|u| u.user.orders }.flatten.compact
+      referred_records_with_user_orders.collect{|u| u.user.orders }.flatten.compact
+    end
+
+    def referral_activated_users
+      referred_records_with_user_orders.select{|u| post_referral_order?(u) }.collect(&:user)
     end
 
     protected
@@ -22,5 +26,15 @@ module Spree
           break code unless Referral.exists?(code: code)
         end
       end
+
+   private
+
+    def referred_records_with_user_orders
+      referred_records.includes({:user => :orders})
+    end
+
+    def post_referral_order?(referred_record)
+      referred_record.user.orders.where('created_at > ?', self.user.created_at).any?
+    end
   end
 end

--- a/spec/models/spree/referral_spec.rb
+++ b/spec/models/spree/referral_spec.rb
@@ -17,19 +17,23 @@ describe Spree::Referral, :type => :model do
       @user = FactoryGirl.create(:user)
       @referred = FactoryGirl.create(:user, referral_code: @user.referral.code)
       @order = FactoryGirl.create(:order, user: @referred)
+      @referred_no_purchase = FactoryGirl.create(:user, referral_code: @user.referral.code)
     end
 
     it "returns an associated user record" do
       expect(@user.referral.user).to_not be_nil
     end
     it "returns referred records" do
-      expect(@user.referral.referred_records.count).to eq(1)
+      expect(@user.referral.referred_records.count).to eq(2)
     end
     it "returns an array of referred users" do
-      expect(@user.referral.referred_users).to eq([@referred])
+      expect(@user.referral.referred_users).to eq([@referred, @referred_no_purchase])
     end
     it "returns an array of referred orders" do
       expect(@user.referral.referred_orders).to eq([@order])
+    end
+    it "returns an array of referral activated users" do
+      expect(@user.referral.referral_activated_users).to eq([@referred])
     end
   end
 end


### PR DESCRIPTION
This adds a referral_activated_users method to the referral so that you can obtain a list of users who have made a purchase from a referral. This referred user could be an existing customer, but they would only be returned by this method if they made an additional purchase. This is useful for example, if you want to offer referral based rewards to customers.