### PR TITLE
Check the order's completed_at date, not its created_at

### DIFF
--- a/app/models/spree/referral.rb
+++ b/app/models/spree/referral.rb
@@ -34,7 +34,7 @@ module Spree
     end
 
     def post_referral_order?(referred_record)
-      referred_record.user.orders.where('created_at > ?', self.user.created_at).any?
+      referred_record.user.orders.where('completed_at > ?', self.user.created_at).any?
     end
   end
 end

--- a/spec/models/spree/referral_spec.rb
+++ b/spec/models/spree/referral_spec.rb
@@ -32,8 +32,10 @@ describe Spree::Referral, :type => :model do
     it "returns an array of referred orders" do
       expect(@user.referral.referred_orders).to eq([@order])
     end
-    it "returns an array of referral activated users" do
-      expect(@user.referral.referral_activated_users).to eq([@referred])
+    it "returns an array of referral activated users with completed_orders" do
+      referred_user_with_completed_order = FactoryGirl.create(:user, referral_code: @user.referral.code)
+      completed_order = FactoryGirl.create(:order, completed_at: @user.created_at + 1.second, user: referred_user_with_completed_order)
+      expect(@user.referral.referral_activated_users).to eq([referred_user_with_completed_order])
     end
   end
 end


### PR DESCRIPTION
`post_referral_order?` should check an order's `completed_at` timestamp, not its `created_at`. In Spree, an order is created during checkout and is only marked as complete when a successful payment has been made (or if it's a free product, that the checkout process has completed).

The `referral_activated_users` method should return users who have completed an order, otherwise it'll return referred users with incomplete orders.