### PR TITLE
Add a data-hook attribute to the Referral Information table

### DIFF
--- a/app/overrides/spree/admin/users/edit.rb
+++ b/app/overrides/spree/admin/users/edit.rb
@@ -4,7 +4,7 @@ Deface::Override.new(
   :insert_after => "[data-hook='admin_user_api_key']"
 ) do
 <<-CODE.chomp
-<fieldset>
+<fieldset data-hook="admin_user_referral_table">
   <legend>Referral Information</legend>
   <table>
     <tr>


### PR DESCRIPTION
Mark up the Referral Information fieldset so it can be targeted by deface overrides.